### PR TITLE
fix float returning as a str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "cuatrorpc_rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cuatrorpc_rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["bleach86 <tux@ghostbyjohnmcafee.com>"]
 description = "Fast RPC client library for Python in rust."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ fn callrpc_cli_rs(
 
 fn _is_numeric<S: AsRef<str>>(input: S) -> bool {
     for char in input.as_ref().chars() {
-        if !char.is_digit(10) {
+        if !matches!(char, '0'..='9' | '.') {
             return false;
         }
     }


### PR DESCRIPTION
This fixes an issue where where the returned value is only a float it would return as a str instead of a float